### PR TITLE
zabbix agent template

### DIFF
--- a/app/zabbix-agent/Makefile
+++ b/app/zabbix-agent/Makefile
@@ -1,0 +1,8 @@
+APP_NAME=$(shell basename $(CURDIR))
+SELINUX_MODULE=rabe$(subst -,,${APP_NAME})
+
+selinux/${SELINUX_MODULE}.pp: selinux/${SELINUX_MODULE}.te
+	make -C selinux NAME=${SELINUX_MODULE} -f /usr/share/selinux/devel/Makefile
+
+clean:
+	rm -rf selinux/*.pp selinux/tmp/

--- a/app/zabbix-agent/README.md
+++ b/app/zabbix-agent/README.md
@@ -1,0 +1,40 @@
+# zabbix-agent
+
+Basic Zabbix Agent operations.
+
+* [Template App Zabbix Agent active](Template_App_Zabbix_Agent_active.xml)
+* [SELinux policy module rabezabbixagent](selinux/rabezabbixagent.te)
+
+## Template
+Based on the [official Zabbix agent template from Zabbix distribution](https://share.zabbix.com/official-templates/applications/zabbix-agent) but made active.
+
+### Items
+
+* Host name of zabbix_agentd running (agent.hostname)
+* Agent ping (agent.ping)
+* Version of zabbix_agent(d) running (agent.version)
+
+### Triggers
+
+* High: No current data from Zabbix agent on {HOST.NAME}
+* Information: Host name of zabbix_agentd was changed on {HOST.NAME}
+* Information: Version of zabbix_agent(d) was changed on {HOST.NAME}
+
+### Macros
+
+* `{$APP_ZABBIX_AGENT_NODATA_HIGH_TIME}`
+
+  Time for which no current data must be available for HIGH trigger (5m per default)
+
+## SELinux Policy
+
+The [rabezabbixagent](selinux/rabezabbixagent.te) policy allows the agent to set its rlimit
+as described by [ZBX-10086](https://support.zabbix.com/browse/ZBX-10086).
+
+## License
+This template is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, version 3 of the License.
+
+## Copyright
+Copyright (c) 2017 [Radio Bern RaBe](http://www.rabe.ch)

--- a/app/zabbix-agent/Template_App_Zabbix_Agent_active.xml
+++ b/app/zabbix-agent/Template_App_Zabbix_Agent_active.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>3.0</version>
+    <date>2017-02-05T12:19:16Z</date>
+    <groups>
+        <group>
+            <name>App templates</name>
+        </group>
+    </groups>
+    <templates>
+        <template>
+            <template>Template App Zabbix Agent active</template>
+            <name>Template App Zabbix Agent active</name>
+            <description/>
+            <groups>
+                <group>
+                    <name>App templates</name>
+                </group>
+            </groups>
+            <applications>
+                <application>
+                    <name>Zabbix agent</name>
+                </application>
+            </applications>
+            <items>
+                <item>
+                    <name>Host name of zabbix_agentd running</name>
+                    <type>7</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>agent.hostname</key>
+                    <delay>3600</delay>
+                    <history>7</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>1</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Zabbix agent</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>Agent ping</name>
+                    <type>7</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>agent.ping</key>
+                    <delay>120</delay>
+                    <history>7</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The agent always returns 1 for this item. It could be used in combination with nodata() for availability check.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Zabbix agent</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>Zabbix agent ping status</name>
+                    </valuemap>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>Version of zabbix_agent(d) running</name>
+                    <type>7</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>agent.version</key>
+                    <delay>3600</delay>
+                    <history>7</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>1</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>Zabbix agent</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+            </items>
+            <discovery_rules/>
+            <macros>
+                <macro>
+                    <macro>{$APP_ZABBIX_AGENT_NODATA_HIGH_TIME}</macro>
+                    <value>5m</value>
+                </macro>
+            </macros>
+            <templates/>
+            <screens/>
+        </template>
+    </templates>
+    <triggers>
+        <trigger>
+            <expression>{Template App Zabbix Agent active:agent.hostname.diff(0)}&gt;0</expression>
+            <name>Host name of zabbix_agentd was changed on {HOST.NAME}</name>
+            <url/>
+            <status>0</status>
+            <priority>1</priority>
+            <description/>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+        <trigger>
+            <expression>{Template App Zabbix Agent active:agent.ping.nodata({$APP_ZABBIX_AGENT_NODATA_HIGH_TIME})}=1</expression>
+            <name>No current data from Zabbix agent on {HOST.NAME}</name>
+            <url/>
+            <status>0</status>
+            <priority>4</priority>
+            <description/>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+        <trigger>
+            <expression>{Template App Zabbix Agent active:agent.version.diff(0)}&gt;0</expression>
+            <name>Version of zabbix_agent(d) was changed on {HOST.NAME}</name>
+            <url/>
+            <status>0</status>
+            <priority>1</priority>
+            <description/>
+            <type>0</type>
+            <dependencies/>
+        </trigger>
+    </triggers>
+    <value_maps>
+        <value_map>
+            <name>Zabbix agent ping status</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>Up</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+    </value_maps>
+</zabbix_export>

--- a/app/zabbix-agent/selinux/rabezabbixagent.te
+++ b/app/zabbix-agent/selinux/rabezabbixagent.te
@@ -1,0 +1,9 @@
+module rabezabbixagent 1.0;
+
+require {
+    type zabbix_agent_t;
+    class process setrlimit;
+}
+
+#============= zabbix_agent_t ==============
+allow zabbix_agent_t self:process setrlimit;


### PR DESCRIPTION
Zabbix wants to set an rlimit for security reasons as noted in https://support.zabbix.com/browse/ZBX-10086. While this should not actually affect an unencrypted agent it does nevertheless.