### PR TITLE
Specfile and Makefiles for RPM building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/selinux/tmp
+**/selinux/*.pp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+all: */Makefile
+	make -C $(dir $<)
+
+clean: */Makefile
+	make -C $(dir $<) clean

--- a/README.md
+++ b/README.md
@@ -28,3 +28,29 @@ This ensures great modularity, reusability and avoids unecessary inheritance pro
 * Use an update interval of 300 seconds (5 minutes) by default
 * Create at least one unique application per app and snmp template
 * Use macros whenever possible and feasible, prefix them with a unique per template prefix
+
+### App specific conventions
+
+* Apps may contain configuration snippets in a `userparameters/` subdir.
+* SELinux policy modules for an app are in the `selinux/` subdir. They are prefixed with "rabe" to help differentiate them from system policy.
+* Apps have a Makefile to aid in compiling the SELinux policy.
+
+## RPM Packages
+
+The rabe-zabbix templates come with an RPM package that helps install SELinux policies and UserParameter configs. We provide a pre-built version
+through the [openSUSE Build Server](https://build.opensuse.org/). They are available as part of the [home:radiorabe:zabbix Subproject](https://build.opensuse.org/project/show/home:radiorabe:zabbix). You can install them as follows.
+
+```bash
+curl -o /etc/yum.repos.d/home:radiorabe:zabbix.repo \
+     http://download.opensuse.org/repositories/home:/radiorabe:/zabbix/CentOS_7/home:radiorabe:zabbix.repo
+
+yum install rabe-zabbix
+```
+
+## License
+This template collection is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, version 3 of the License.
+
+## Copyright
+Copyright (c) 2017 [Radio Bern RaBe](http://www.rabe.ch)

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,0 +1,5 @@
+all: */Makefile
+	make -C $(dir $<)
+
+clean: */Makefile
+	make -C $(dir $<) clean

--- a/rabe-zabbix.spec
+++ b/rabe-zabbix.spec
@@ -1,0 +1,77 @@
+#
+# spec file for package rabe-zabbix
+#
+# Copyright (c) 2017 Radio Bern RaBe
+#                    http://www.rabe.ch
+#
+# This program is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public 
+# License as published  by the Free Software Foundation, version
+# 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License  along with this program.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+# Please submit enhancements, bugfixes or comments via GitHub:
+# https://github.com/radiorabe/rabe-zabbix
+#
+
+Name:          rabe-zabbix
+Version:       master
+Release:       0
+Summary:       RaBe Zabbix scripts and configs
+License:       AGPLv3
+Source:        rabe-zabbix-%{version}.tar.gz
+
+BuildArch:     noarch
+
+Requires:      zabbix-agent
+# requires for selinux packaging
+BuildRequires: checkpolicy, selinux-policy-devel, /usr/share/selinux/devel/policyhelp
+%{!?_selinux_policy_version: %global _selinux_policy_version %(sed -e 's,.*selinux-policy-\\([^/]*\\)/.*,\\1,' /usr/share/selinux/devel/policyhelp 2>/dev/null)}
+%if "%{_selinux_policy_version}" != ""
+Requires:      selinux-policy >= %{_selinux_policy_version}
+%endif
+Requires(post):   /usr/sbin/semodule, /sbin/restorecon, /sbin/fixfiles
+Requires(postun): /usr/sbin/semodule, /sbin/restorecon, /sbin/fixfiles
+
+%description
+Contains helper scripts, UserParameter configs, SELinux policies to be used at RaBe for monitoring all the things.
+
+%prep
+%setup -q -n %{name}-%{version}
+
+%build
+make
+
+%install
+install -d %{buildroot}%{_datadir}/selinux/targeted
+for policy in `find -name '*.pp'`; do
+  install -p -m 644 ${policy} %{buildroot}%{_datadir}/selinux/targeted/`basename ${policy}`
+  echo -n "`basename -s .pp ${policy}` " >> %{buildroot}%{_datadir}/selinux/targeted/rabe.lst
+done
+
+%post
+for policy in `cat %{_datadir}/selinux/targeted/rabe.lst`; do
+  /usr/sbin/semodule -s targeted -i %{_datadir}/selinux/targeted/${policy}.pp &> /dev/null || :
+done
+/sbin/fixfiles -R rabe-zabbix restore || :
+
+%preun
+if [ $1 -eq 0 ] ; then
+  for policy in `cat %{_datadir}/selinux/targeted/rabe.lst`; do
+    /usr/sbin/semodule -s targeted -r ${policy} &> /dev/null || :
+  done
+  /sbin/fixfiles -R rabe-zabbix restore || :
+fi
+
+%files
+%defattr(-,root,root,0755)
+%{_datadir}/selinux/*/rabe.lst
+%{_datadir}/selinux/*/*.pp


### PR DESCRIPTION
* Add RPM Info and License to README.md
* Require zabbix-agent to prepopulate /etc dirs
* Install SELinux policy modules [1]

[1] Mostly based on https://fedoraproject.org/wiki/SELinux_Policy_Modules_Packaging_Draft. Uses a rabe.lst file so %post and %preun know what to operate on without anything being hardcoded in the specfile.