### PR TITLE
Make Makefile self-documenting

### DIFF
--- a/rabe-zabbix.spec
+++ b/rabe-zabbix.spec
@@ -48,7 +48,7 @@ Contains helper scripts, UserParameter configs, SELinux policies and sudoers to 
 %setup -q -n %{name}-%{version}
 
 %build
-make -j2
+make -j2 build
 
 %install
 make install PREFIX=%{buildroot}%{_prefix} ETCDIR=%{buildroot}%{_sysconfdir}


### PR DESCRIPTION
With this you can run plain `make` to get a list of end-user callable make targets.

As documented on [marmelab.com](
https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html).

I'm also adding `.PHONY` annotations to all the targets that don't create or change any actual files.