### PR TITLE
Feature - Updating naming convention for app folder/files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,61 +41,72 @@ This ensures great modularity, reusability and avoids unecessary inheritance pro
 ```bash
 appName="" # app name
 
-templateName="Template App ${appName} active"
+lowercaseName="${appName,,}"
+shortName="${lowercaseName//-/}"
 
-shortName=${appName//-/}
+templateName="Template App ${appName} active"
 xmlName="${templateName// /_}.xml"
 
-mkdir -p app/${appName}/doc
-touch app/${appName}/doc/README.head.md
+appDir="app/${appName// /_}"
 
-mv zbx_export_templates.xml app/${appName}/${xmlName}
+mkdir -p "${appDir}/doc"
+touch "${appDir}/doc/README.head.md"
+
+mv zbx_export_templates.xml "${appDir}/${xmlName}"
 ```
+
 #### optional selinux policy
 ```bash
 $avcViolation="" # multiple lines from /var/log/audit/audit.log
 
-mkdir app/${appName}/selinux
+moduleName="rabezbx${shortName// /}"
 
-echo ${avcViolation} | audit2allow -m rabezbx${appName} > \
-  app/${appName}/selinux/rabezbx${shortName}.te
+mkdir "${appDir}/selinux"
 
-cat > app/${appName}/doc/README.SELinux.md <<EOD
+echo ${avcViolation} | audit2allow -m ${moduleName} > \
+  "${appDir}/selinux/${moduleName}.te"
+
+cat > "${appDir}/doc/README.SELinux.md" <<EOD
 ## SELinux Policy
 
-The [rabezbx${appName}](selinux/rabezbx${appName}.te) policy does <dox>.
+The [${moduleName}](selinux/${moduleName}.te) policy does <dox>.
 EOD
 ```
+
 #### optional userparameters
 ```bash
-mkdir app/${appName}/userparameters
+mkdir "${appDir}/userparameters"
 
-cat > app/${appName}/userparameters/rabe.${appName}.conf <<EOD
+userParameterName="rabe.${lowercaseName// /-}"
+
+cat > "${appDir}/userparameters/${userParameterName}.conf" <<EOD
 #
 # dox here
 #
-UserParameter=rabe.${appName}.<key>,<script>
+UserParameter=${userParameterName}.<key>,<script>
 EOD
 
-cat > app/${appName}/doc/README.UserParameters.md <<EOD
+cat > "${appDir}/doc/README.UserParameters.md" <<EOD
 ## UserParameters
 
 | Key | Description |
 | --- | ----------- |
-| \`rabe.${appName}.<key>\` | <dox> |
+| \`${userParameterName}.<key>\` | <dox> |
 EOD
 ```
 
 #### optional scripts
 ```bash
-mkdir app/${appName}/scripts
+mkdir "${appDir}/scripts"
 
-touch app/${appName}/scripts/rabe-${appName}.sh
+scriptName="rabe-${lowercaseName// /-}.sh"
 
-cat > app/${appName}/doc/README.scripts.md <<EOD
+touch "${appDir}/scripts/${scriptName}"
+
+cat > "${appDir}/doc/README.scripts.md" <<EOD
 ## Scripts
 
-* [rabe-${appName}.sh](./scripts/rabe-${appName}.sh) for rabe.${appName}.<key> UserParameter
+* [${scriptName}](./scripts/${scriptName}) for ${userParameterName}.<key> UserParameter
 
 <dox below listing if needed>
 EOD


### PR DESCRIPTION
This (hopefully) finalizes the naming convention for app folders,
templates, user parameters, scripts and SELinux modules.

It is based upon the discussion at https://github.com/radiorabe/rabe-zabbix/pull/15#issuecomment-312489022 and shouldn't brake any existing file and folder names.

The naming convention results in the following directory and file
structure for an app named `My First-Example App`:
```
app/My_First-Example_App/
├── doc
│   ├── README.head.md
│   ├── README.scripts.md
│   ├── README.SELinux.md
│   └── README.UserParameters.md
├── scripts
│   └── rabe-my-first-example-app.sh
├── selinux
│   └── rabezbxmyfirstexampleapp.te
├── Template_App_My_First-Example_App_active.xml
└── userparameters
    └── rabe.my-first-example-app.conf
```