### PR TITLE
update-app-doc: Refactored markdown generation into templates.

### DIFF
--- a/app/CARP/README.md
+++ b/app/CARP/README.md
@@ -15,54 +15,44 @@ The discovery rules and user parameters were tested on
 
 This template is part of [RaBe's Zabbix template and helpers
 collection](https://github.com/radiorabe/rabe-zabbix).
-
 ## Template App CARP active
-
 Application template for monitoring the Common Address Redundancy Protocol (CARP) on FreeBSD network interfaces.
 - https://www.freebsd.org/doc/handbook/carp.html
 - https://www.freebsd.org/cgi/man.cgi?query=carp&sektion=4
 ### Discovery
 #### CARP vhid discovery (`rabe.carp.vhid.discovery`)
-
 Low-Level discovery of FreeBSD's configured CARP virtual host IDs (vhid).
 
 Returns the following example macro for each configured vhid:
 {#CARP_VHID} = 3
-
 ##### Item Prototypes
-* CARP advbase of vhid $1 (`rabe.carp.vhid.advbase[{#CARP_VHID}]`)
-
-The current advertisement base in seconds of a specific CARP virtual host ID (vhid).
-
-* CARP advskew of vhid $1 (`rabe.carp.vhid.advskew[{#CARP_VHID}]`)
-
-The current advertisement skew in 1/256 second (as per the carp(4) man page) of a specific CARP virtual host ID (vhid).
-
-* CARP status of vhid $1 (`rabe.carp.vhid.status[{#CARP_VHID}]`)
-
-The current status of a specific CARP virtual host ID (vhid).
-
+* CARP advbase of vhid $1 (`rabe.carp.vhid.advbase[{#CARP_VHID}]`)  
+  The current advertisement base in seconds of a specific CARP virtual host ID (vhid).
+* CARP advskew of vhid $1 (`rabe.carp.vhid.advskew[{#CARP_VHID}]`)  
+  The current advertisement skew in 1/256 second (as per the carp(4) man page) of a specific CARP virtual host ID (vhid).
+* CARP status of vhid $1 (`rabe.carp.vhid.status[{#CARP_VHID}]`)  
+  The current status of a specific CARP virtual host ID (vhid).
 ##### Trigger Prototypes
-* CARP status of VHID {#CARP_VHID} changed to {ITEM.VALUE1} on {HOST.NAME} (`{Template App CARP active:rabe.carp.vhid.status[{#CARP_VHID}].diff()}>0`)
-
-The CARP virtual host ID (vhid) changed its status.
+* Information: CARP status of VHID {#CARP_VHID} changed to {ITEM.VALUE1} on {HOST.NAME}
+  ```
+  {Template App CARP active:rabe.carp.vhid.status[{#CARP_VHID}].diff()}>0
+  ```
+  The CARP virtual host ID (vhid) changed its status.
 #### CARP vip discovery (`rabe.carp.vip.discovery`)
-
 Low-Level discovery of FreeBSD's configured CARP virtual IP addresses (vip).
 
 Returns the following example macro pair for each configured CARP VIP
 {#CARP_IP} = 192.0.2.10
 {#CARP_VHID} = 3
-
 ##### Item Prototypes
-* CARP status of VIP $2 in vhid $1 (`rabe.carp.vhid.status[{#CARP_VHID},{#CARP_IP}]`)
-
-The current status of a specific CARP virtual IP address within a virtual host ID (vhid) group.
-
+* CARP status of VIP $2 in vhid $1 (`rabe.carp.vhid.status[{#CARP_VHID},{#CARP_IP}]`)  
+  The current status of a specific CARP virtual IP address within a virtual host ID (vhid) group.
 ##### Trigger Prototypes
-* CARP status of VIP {#CARP_IP} (VHID {#CARP_VHID}) changed to {ITEM.VALUE1} on {HOST.NAME} (`{Template App CARP active:rabe.carp.vhid.status[{#CARP_VHID},{#CARP_IP}].diff()}>0`)
-
-The CARP virtual IP address (vip) within a virtual host ID (vhid) group changed its status.
+* Information: CARP status of VIP {#CARP_IP} (VHID {#CARP_VHID}) changed to {ITEM.VALUE1} on {HOST.NAME}
+  ```
+  {Template App CARP active:rabe.carp.vhid.status[{#CARP_VHID},{#CARP_IP}].diff()}>0
+  ```
+  The CARP virtual IP address (vip) within a virtual host ID (vhid) group changed its status.
 ## UserParameters
 
 The following user parameters are available within [`rabe.carp.conf`](userparameters/rabe.carp.conf)

--- a/app/chrony/README.md
+++ b/app/chrony/README.md
@@ -4,17 +4,16 @@ Basic chrony NTP client monitoring.
 
 This template is part of [RaBe's Zabbix template and helpers
 collection](https://github.com/radiorabe/rabe-zabbix).
-
 ## Template App chrony active
-### Items 
-* Memory usage (rss) of "chronyd" processes (`proc.mem[chronyd,chrony,,,rss]`)
-* Number of "chronyd" processes (`proc.num[chronyd,chrony]`)
+### Items
+* Memory usage (rss) of "chronyd" processes (`proc.mem[chronyd,chrony,,,rss]`)  
+* Number of "chronyd" processes (`proc.num[chronyd,chrony]`)  
 ### Triggers
-
-* High: No running chronyd processes on {HOST.NAME} (`{Template App chrony active:proc.num[chronyd,chrony].max(#5)}<1`)
-
-We expect chronyd to to run at all times
-
+* High: No running chronyd processes on {HOST.NAME}
+  ```
+  {Template App chrony active:proc.num[chronyd,chrony].max(#5)}<1
+  ```
+  We expect chronyd to to run at all times
 
 ## License
 This template is free software: you can redistribute it and/or modify it under

--- a/app/ntpd/README.md
+++ b/app/ntpd/README.md
@@ -14,44 +14,45 @@ template which the individual server and client templates reference.
 
 This template is part of [RaBe's Zabbix template and helpers
 collection](https://github.com/radiorabe/rabe-zabbix).
-
-## Template App ntpd Client active### Discovery
+## Template App ntpd Client active
+### Discovery
 #### NTP servers (`rabe.ntpd.server.discovery`)
 ##### Item Prototypes
-* NTP server {#SERVERNAME} candidate order (`rabe.ntpd.server.candidate_order[{#SERVERNAME}]`)
-* NTP server {#SERVERNAME} configuration (`vfs.file.regexp[/etc/ntp.conf,"^server.*{#SERVERNAME} (.*)",,,,\1]`)
+* NTP server {#SERVERNAME} candidate order (`rabe.ntpd.server.candidate_order[{#SERVERNAME}]`)  
+* NTP server {#SERVERNAME} configuration (`vfs.file.regexp[/etc/ntp.conf,"^server.*{#SERVERNAME} (.*)",,,,\1]`)  
 ##### Trigger Prototypes
-* NTP server {#SERVERNAME} is not a valid candidate on {HOST.NAME} (`{Template App ntpd Client active:rabe.ntpd.server.candidate_order[{#SERVERNAME}].last()}=0`)
-
-If a configured server has a candidate order of 0 it is not considered as a valid time source and most likely has some issues.
-
+* Warning: NTP server {#SERVERNAME} is not a valid candidate on {HOST.NAME}
+  ```
+  {Template App ntpd Client active:rabe.ntpd.server.candidate_order[{#SERVERNAME}].last()}=0
+  ```
+  If a configured server has a candidate order of 0 it is not considered as a valid time source and most likely has some issues.
 ## Template App ntpd Common active
-### Items 
-* Memory usage (rss) of "ntpd" processes (`proc.mem[ntpd,ntp,,,rss]`)
-* Number of "ntpd" processes (`proc.num[ntpd,ntp]`)
-* ntpd authdelay (`rabe.ntpdc.sysinfo[authdelay,single]`)
-* ntpd broadcastdelay (`rabe.ntpdc.sysinfo[broadcastdelay,single]`)
-* ntpd jitter (`rabe.ntpdc.sysinfo[jitter,single]`)
-* ntpd precision (`rabe.ntpdc.sysinfo[precision]`)
-* ntpd root dispersion (`rabe.ntpdc.sysinfo[root dispersion,single]`)
-* ntpd root distance (`rabe.ntpdc.sysinfo[root distance,single]`)
-* ntpd stability (`rabe.ntpdc.sysinfo[stability,single]`)
-* ntpd stratum (`rabe.ntpdc.sysinfo[stratum]`)
-* ntpd system flags (`rabe.ntpdc.sysinfo[system flags]`)
-* ntpd system peer mode (`rabe.ntpdc.sysinfo[system peer mode]`)
-* ntpd system peer (`rabe.ntpdc.sysinfo[system peer]`)
+### Items
+* Memory usage (rss) of "ntpd" processes (`proc.mem[ntpd,ntp,,,rss]`)  
+* Number of "ntpd" processes (`proc.num[ntpd,ntp]`)  
+* ntpd authdelay (`rabe.ntpdc.sysinfo[authdelay,single]`)  
+* ntpd broadcastdelay (`rabe.ntpdc.sysinfo[broadcastdelay,single]`)  
+* ntpd jitter (`rabe.ntpdc.sysinfo[jitter,single]`)  
+* ntpd precision (`rabe.ntpdc.sysinfo[precision]`)  
+* ntpd root dispersion (`rabe.ntpdc.sysinfo[root dispersion,single]`)  
+* ntpd root distance (`rabe.ntpdc.sysinfo[root distance,single]`)  
+* ntpd stability (`rabe.ntpdc.sysinfo[stability,single]`)  
+* ntpd stratum (`rabe.ntpdc.sysinfo[stratum]`)  
+* ntpd system flags (`rabe.ntpdc.sysinfo[system flags]`)  
+* ntpd system peer mode (`rabe.ntpdc.sysinfo[system peer mode]`)  
+* ntpd system peer (`rabe.ntpdc.sysinfo[system peer]`)  
 ## Template App ntpd Server active
 ### Triggers
-
-* High: No running ntpd processes on {HOST.NAME} (`{Template App ntpd Common active:proc.num[ntpd,ntp].max(#5)}<1`)
-
-We expect ntpd to run at all times
-
-
-* Warning: ntpd system peer mode is not client on host {HOST.NAME} (`{Template App ntpd Common active:rabe.ntpdc.sysinfo[system peer mode].regexp(client)}<>0`)
-
-Our clients should always be in client peer mode. If they are not, chances are that they are not clients any more.
-
+* High: No running ntpd processes on {HOST.NAME}
+  ```
+  {Template App ntpd Common active:proc.num[ntpd,ntp].max(#5)}<1
+  ```
+  We expect ntpd to run at all times
+* Warning: ntpd system peer mode is not client on host {HOST.NAME}
+  ```
+  {Template App ntpd Common active:rabe.ntpdc.sysinfo[system peer mode].regexp(client)}<>0
+  ```
+  Our clients should always be in client peer mode. If they are not, chances are that they are not clients any more.
 ## SELinux Policy
 
 The [rabezbxntpd](selinux/rabezbxntpd.te) policy allows the agent to access ntpd configuration files.

--- a/app/zabbix-agent/README.md
+++ b/app/zabbix-agent/README.md
@@ -6,28 +6,28 @@ Based on the [official Zabbix agent template from Zabbix distribution](https://s
 
 This template is part of [RaBe's Zabbix template and helpers
 collection](https://github.com/radiorabe/rabe-zabbix).
-
 ## Template App Zabbix Agent active
-
 This template is part of RaBe's Zabbix template and helpers collection at https://github.com/radiorabe/rabe-zabbix.
-
-### Items 
-* Host name of zabbix_agentd running (`agent.hostname`)
-* Agent ping (`agent.ping`)
-
-The agent always returns 1 for this item. It could be used in combination with nodata() for availability check.
-
-* Version of zabbix_agent(d) running (`agent.version`)
+### Items
+* Host name of zabbix_agentd running (`agent.hostname`)  
+* Agent ping (`agent.ping`)  
+  The agent always returns 1 for this item. It could be used in combination with nodata() for availability check.
+* Version of zabbix_agent(d) running (`agent.version`)  
 ### Macros
-
 * `{$APP_ZABBIX_AGENT_NODATA_HIGH_TIME}` (default: 5m)
 ### Triggers
-
-* Information: Host name of zabbix_agentd was changed on {HOST.NAME} (`{Template App Zabbix Agent active:agent.hostname.diff(0)}>0`)
-
-* High: No current data from Zabbix agent on {HOST.NAME} (`{Template App Zabbix Agent active:agent.ping.nodata({$APP_ZABBIX_AGENT_NODATA_HIGH_TIME})}=1`)
-
-* Information: Version of zabbix_agent(d) was changed on {HOST.NAME} (`{Template App Zabbix Agent active:agent.version.diff(0)}>0`)
+* Information: Host name of zabbix_agentd was changed on {HOST.NAME}
+  ```
+  {Template App Zabbix Agent active:agent.hostname.diff(0)}>0
+  ```
+* High: No current data from Zabbix agent on {HOST.NAME}
+  ```
+  {Template App Zabbix Agent active:agent.ping.nodata({$APP_ZABBIX_AGENT_NODATA_HIGH_TIME})}=1
+  ```
+* Information: Version of zabbix_agent(d) was changed on {HOST.NAME}
+  ```
+  {Template App Zabbix Agent active:agent.version.diff(0)}>0
+  ```
 ## SELinux Policy
 
 The [rabezbxzabbixagent](selinux/rabezbxzabbixagent.te) policy allows the agent to set its rlimit

--- a/update-app-doc.xsl
+++ b/update-app-doc.xsl
@@ -8,12 +8,134 @@
   <xsl:param name="userparamDoc"/>
   <xsl:param name="scriptDoc"/>
 
-  <!-- add a description to a * list of items -->
-  <xsl:template name="output-description-if-available"><xsl:if test="description != ''"><xsl:text>
+  <!-- add a description with a newline -->
+  <xsl:template name="output-description-if-available">
+    <xsl:param name="indent"></xsl:param>
+    <xsl:if test="description != ''">
+      <xsl:value-of select="$indent"/>
+      <xsl:value-of select="description"/>
+      <xsl:text>&#xa;</xsl:text>
+    </xsl:if>
+  </xsl:template>
 
-</xsl:text><xsl:value-of select="description"/><xsl:text>
-</xsl:text>
-</xsl:if></xsl:template>
+  <!-- add a markdown inline-code "`Code`" -->
+  <xsl:template name="md-inline-code">
+    <xsl:param name="code">Code</xsl:param>
+    <xsl:param name="indent"></xsl:param>
+    <xsl:value-of select="$indent"/>
+    <xsl:text>`</xsl:text>
+    <xsl:value-of select="$code"/>
+    <xsl:text>`</xsl:text>
+  </xsl:template>
+
+  <!-- add a markdown code block
+       ```
+       Code
+       ```
+  -->
+  <xsl:template name="md-code-block">
+    <xsl:param name="code">Code</xsl:param>
+    <xsl:param name="indent"></xsl:param>
+    <xsl:value-of select="$indent"/><xsl:text>```&#xa;</xsl:text>
+    <xsl:value-of select="$indent"/><xsl:value-of select="$code"/>
+    <xsl:text>&#xa;</xsl:text>
+    <xsl:value-of select="$indent"/><xsl:text>```&#xa;</xsl:text>
+  </xsl:template>
+
+  <!-- add a markdown bullet item: "* Text" -->
+  <xsl:template name="md-bullet">
+    <xsl:param name="text">Text</xsl:param>
+    <xsl:param name="indent"></xsl:param>
+    <xsl:value-of select="$indent"/><xsl:text>* </xsl:text>
+    <xsl:value-of select="$text"/>
+    <xsl:text>&#xa;</xsl:text>
+  </xsl:template>
+
+  <!-- add a markdown bullet with code in parentheses "* Text (`Code`)" -->
+  <xsl:template name="md-bullet-with-code">
+    <xsl:param name="text">Text</xsl:param>
+    <xsl:param name="code">Code</xsl:param>
+    <xsl:param name="indent"></xsl:param>
+    <xsl:call-template name="md-bullet">
+      <xsl:with-param name="text">
+        <xsl:value-of select="$text"/>
+        <xsl:text> (</xsl:text>
+        <xsl:call-template name="md-inline-code">
+          <xsl:with-param name="code" select="$code"/>
+          <xsl:with-param name="indent" select="$indent"/>
+        </xsl:call-template>
+        <xsl:text>)  </xsl:text>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
+
+  <!-- add a markdown "trigger" bullet with priority "* PRIORITY: text" -->
+  <xsl:template name="md-trigger-bullet">
+    <xsl:param name="text">Text</xsl:param>
+    <xsl:param name="priority">0</xsl:param>
+    <xsl:param name="indent"></xsl:param>
+    <xsl:call-template name="md-bullet">
+      <xsl:with-param name="text">
+        <xsl:choose>
+          <xsl:when test="$priority = 0">Not classified</xsl:when>
+          <xsl:when test="$priority = 1">Information</xsl:when>
+          <xsl:when test="$priority = 2">Warning</xsl:when>
+          <xsl:when test="$priority = 3">Average</xsl:when>
+          <xsl:when test="$priority = 4">High</xsl:when>
+          <xsl:when test="$priority = 5">Disaster</xsl:when>
+        </xsl:choose>: <xsl:value-of select="$text"/>
+      </xsl:with-param>
+      <xsl:with-param name="indent" select="$indent"/>
+    </xsl:call-template>
+  </xsl:template>
+
+  <!-- add a markdown heading 1 with a trailing new line -->
+  <xsl:template name="md-h1">
+    <xsl:param name="title">Heading 1</xsl:param>
+    <xsl:text># </xsl:text>
+    <xsl:value-of select="$title"/>
+    <xsl:text>&#xa;</xsl:text>
+  </xsl:template>
+
+  <!-- add a markdown heading 2 with a trailing new line -->
+  <xsl:template name="md-h2">
+    <xsl:param name="title">Heading 2</xsl:param>
+    <xsl:text>## </xsl:text>
+    <xsl:value-of select="$title"/>
+    <xsl:text>&#xa;</xsl:text>
+  </xsl:template>
+
+  <!-- add a markdown heading 3 with a trailing new line -->
+  <xsl:template name="md-h3">
+    <xsl:param name="title">Heading 3</xsl:param>
+    <xsl:text>### </xsl:text>
+    <xsl:value-of select="$title"/>
+    <xsl:text>&#xa;</xsl:text>
+  </xsl:template>
+
+  <!-- add a markdown heading 4 with a trailing new line -->
+  <xsl:template name="md-h4">
+    <xsl:param name="title">Heading 4</xsl:param>
+    <xsl:text>#### </xsl:text>
+    <xsl:value-of select="$title"/>
+    <xsl:text>&#xa;</xsl:text>
+  </xsl:template>
+
+  <!-- add a markdown heading 5 with a trailing new line -->
+  <xsl:template name="md-h5">
+    <xsl:param name="title">Heading 5</xsl:param>
+    <xsl:text>##### </xsl:text>
+    <xsl:value-of select="$title"/>
+    <xsl:text>&#xa;</xsl:text>
+  </xsl:template>
+
+  <!-- add a markdown heading 6 with a trailing new line -->
+  <xsl:template name="md-h6">
+    <xsl:param name="title">Heading 6</xsl:param>
+    <xsl:text>###### </xsl:text>
+    <xsl:value-of select="$title"/>
+    <xsl:text>&#xa;</xsl:text>
+  </xsl:template>
 
   <!-- str:split template from http://exslt.org/ -->
   <xsl:template name="str:split">
@@ -181,37 +303,78 @@ Copyright (c) 2017 [Radio Bern RaBe](http://www.rabe.ch)
 
   <!-- per template template -->
   <xsl:template match="template">
-## <xsl:value-of select="name" /><xsl:text></xsl:text><xsl:call-template name="output-description-if-available"/>
-<xsl:apply-templates select="items"/>
-<xsl:apply-templates select="macros"/>
-<xsl:apply-templates select="discovery_rules"/>
+    <xsl:call-template name="md-h2">
+      <xsl:with-param name="title" select="name"/>
+    </xsl:call-template>
+    <xsl:call-template name="output-description-if-available"/>
+    <xsl:apply-templates select="items"/>
+    <xsl:apply-templates select="macros"/>
+    <xsl:apply-templates select="discovery_rules"/>
   </xsl:template>
 
   <!-- trigger templates -->
-  <xsl:template match="triggers"><xsl:if test="trigger">
-### Triggers
-<xsl:apply-templates select="trigger"/></xsl:if></xsl:template>
+  <xsl:template match="triggers">
+    <xsl:if test="trigger">
+      <xsl:call-template name="md-h3">
+        <xsl:with-param name="title">
+          <xsl:text>Triggers</xsl:text>
+        </xsl:with-param>
+      </xsl:call-template>
+      <xsl:apply-templates select="trigger"/>
+    </xsl:if>
+  </xsl:template>
+
   <xsl:template match="trigger">
-* <xsl:choose>
-    <xsl:when test="priority = 0">Not classified</xsl:when>
-    <xsl:when test="priority = 1">Information</xsl:when>
-    <xsl:when test="priority = 2">Warning</xsl:when>
-    <xsl:when test="priority = 3">Average</xsl:when>
-    <xsl:when test="priority = 4">High</xsl:when>
-    <xsl:when test="priority = 5">Disaster</xsl:when>
-  </xsl:choose>: <xsl:value-of select="name"/> (`<xsl:value-of select="expression"/>`)<xsl:call-template name="output-description-if-available"/><xsl:text>
-</xsl:text></xsl:template>
+    <xsl:call-template name="md-trigger-bullet">
+      <xsl:with-param name="text" select="name"/>
+      <xsl:with-param name="priority" select="priority"/>
+    </xsl:call-template>
+    <xsl:call-template name="md-code-block">
+      <xsl:with-param name="code" select="expression"/>
+      <xsl:with-param name="indent" select="'  '"/>
+    </xsl:call-template>
+    <xsl:call-template name="output-description-if-available">
+      <xsl:with-param name="indent" select="'  '"/>
+    </xsl:call-template>
+  </xsl:template>
 
   <!-- macro templates -->
-  <xsl:template match="macros"><xsl:if test="macro">
-### Macros
-<xsl:apply-templates select="macro"/></xsl:if></xsl:template>
+  <xsl:template match="macros">
+    <xsl:if test="macro">
+      <xsl:call-template name="md-h3">
+        <xsl:with-param name="title">
+          <xsl:text>Macros</xsl:text>
+        </xsl:with-param>
+      </xsl:call-template>
+      <xsl:apply-templates select="macro"/>
+    </xsl:if>
+  </xsl:template>
+
   <xsl:template match="macro">
-* `<xsl:value-of select="macro"/>` (default: <xsl:value-of select="value"/>)</xsl:template>
+    <xsl:call-template name="md-bullet">
+      <xsl:with-param name="text">
+        <xsl:call-template name="md-inline-code">
+          <xsl:with-param name="code" select="macro"/>
+        </xsl:call-template>
+        <xsl:text> (default: </xsl:text>
+        <xsl:value-of select="value"/>
+        <xsl:text>)</xsl:text>
+      </xsl:with-param>
+    </xsl:call-template>
+  </xsl:template>
 
   <!-- item templates -->
-  <xsl:template match="items"><xsl:if test="item">
-### Items <xsl:apply-templates select="item"/></xsl:if></xsl:template>
+  <xsl:template match="items">
+    <xsl:if test="item">
+      <xsl:call-template name="md-h3">
+        <xsl:with-param name="title">
+          <xsl:text>Items</xsl:text>
+        </xsl:with-param>
+      </xsl:call-template>
+      <xsl:apply-templates select="item"/>
+    </xsl:if>
+  </xsl:template>
+
   <xsl:template match="item">
     <xsl:variable name="items">
       <xsl:value-of select="str:replace(substring-before(substring-after(key, '['), ']'), ',', ', ')"/>
@@ -220,31 +383,89 @@ Copyright (c) 2017 [Radio Bern RaBe](http://www.rabe.ch)
       <!-- get name with replaced '$1', ... placeholders in a slightly hacky exslt fashion (supports up to $5 args) -->
       <xsl:value-of select="str:replace(str:replace(str:replace(str:replace(str:replace(name, '$1', normalize-space(str:split($items, ',')[1])), '$2', normalize-space(str:split($items, ',')[2])), '$3', normalize-space(str:split($items, ',')[3])), '$4', normalize-space(str:split($items, ',')[4])), '$5', normalize-space(str:split($items, ',')[5]))"/>
     </xsl:variable>
-* <xsl:value-of select="$resolvedName"/> (`<xsl:value-of select="key"/>`)<xsl:call-template name="output-description-if-available"/></xsl:template>
+    <xsl:call-template name="md-bullet-with-code">
+      <xsl:with-param name="text" select="$resolvedName"/>
+      <xsl:with-param name="code" select="key"/>
+    </xsl:call-template>
+    <xsl:call-template name="output-description-if-available">
+      <xsl:with-param name="indent" select="'  '"/>
+    </xsl:call-template>
+  </xsl:template>
 
   <!-- discovery rule templates -->
-  <xsl:template match="discovery_rules"><xsl:if test="discovery_rule"><xsl:text>### Discovery
-</xsl:text><xsl:apply-templates select="discovery_rule"/></xsl:if></xsl:template>
-  <xsl:template match="discovery_rule"><xsl:text>#### </xsl:text><xsl:value-of select="name"/> (`<xsl:value-of select="key"/><xsl:text>`)</xsl:text><xsl:call-template name="output-description-if-available"/>
-<xsl:if test="item_prototypes"><xsl:apply-templates select="item_prototypes"/></xsl:if>
-<xsl:if test="trigger_prototypes"><xsl:apply-templates select="trigger_prototypes"/></xsl:if>
-</xsl:template>
+  <xsl:template match="discovery_rules">
+    <xsl:if test="discovery_rule">
+      <xsl:call-template name="md-h3">
+        <xsl:with-param name="title">
+          <xsl:text>Discovery</xsl:text>
+        </xsl:with-param>
+      </xsl:call-template>
+      <xsl:apply-templates select="discovery_rule"/>
+    </xsl:if>
+ </xsl:template>
+
+  <xsl:template match="discovery_rule">
+    <xsl:call-template name="md-h4">
+      <xsl:with-param name="title">
+        <xsl:value-of select="name"/> (`<xsl:value-of select="key"/><xsl:text>`)</xsl:text>
+      </xsl:with-param>
+    </xsl:call-template>
+    <xsl:call-template name="output-description-if-available"/>
+    <xsl:if test="item_prototypes">
+      <xsl:apply-templates select="item_prototypes"/>
+    </xsl:if>
+    <xsl:if test="trigger_prototypes">
+      <xsl:apply-templates select="trigger_prototypes"/>
+    </xsl:if>
+  </xsl:template>
 
   <!-- item prototypes -->
-  <xsl:template match="item_prototypes"><xsl:if test="item_prototype"><xsl:text>
-##### Item Prototypes</xsl:text><xsl:apply-templates select="item_prototype"/>
-</xsl:if></xsl:template>
+  <xsl:template match="item_prototypes">
+    <xsl:if test="item_prototype">
+      <xsl:call-template name="md-h5">
+        <xsl:with-param name="title">
+          <xsl:text>Item Prototypes</xsl:text>
+        </xsl:with-param>
+      </xsl:call-template>
+      <xsl:apply-templates select="item_prototype"/>
+    </xsl:if>
+  </xsl:template>
+
   <xsl:template match="item_prototype">
-* <xsl:value-of select="name"/> (`<xsl:value-of select="key"/>`)<xsl:call-template name="output-description-if-available"/>
-</xsl:template>
+    <xsl:call-template name="md-bullet-with-code">
+      <xsl:with-param name="text" select="name"/>
+      <xsl:with-param name="code" select="key"/>
+    </xsl:call-template>
+   <xsl:call-template name="output-description-if-available">
+      <xsl:with-param name="indent" select="'  '"/>
+   </xsl:call-template>
+  </xsl:template>
 
   <!-- trigger prototypes -->
-  <xsl:template match="trigger_prototypes"><xsl:if test="trigger_prototype"><xsl:text>
-##### Trigger Prototypes</xsl:text><xsl:apply-templates select="trigger_prototype"/>
-</xsl:if></xsl:template>
+  <xsl:template match="trigger_prototypes">
+    <xsl:if test="trigger_prototype">
+      <xsl:call-template name="md-h5">
+        <xsl:with-param name="title">
+          <xsl:text>Trigger Prototypes</xsl:text>
+        </xsl:with-param>
+      </xsl:call-template>
+      <xsl:apply-templates select="trigger_prototype"/>
+    </xsl:if>
+  </xsl:template>
+
   <xsl:template match="trigger_prototype">
-* <xsl:value-of select="name"/> (`<xsl:value-of select="expression"/>`)<xsl:call-template name="output-description-if-available"/>
-</xsl:template>
+    <xsl:call-template name="md-trigger-bullet">
+      <xsl:with-param name="text" select="name"/>
+      <xsl:with-param name="priority" select="priority"/>
+    </xsl:call-template>
+    <xsl:call-template name="md-code-block">
+      <xsl:with-param name="code" select="expression"/>
+      <xsl:with-param name="indent" select="'  '"/>
+    </xsl:call-template>
+    <xsl:call-template name="output-description-if-available">
+      <xsl:with-param name="indent" select="'  '"/>
+   </xsl:call-template>
+  </xsl:template>
 
   <!-- catch all remaining text -->
   <xsl:template match="text()"/>


### PR DESCRIPTION
The previous markdown generation lead to problems with new-lines and
indenting which was hard to spot and fix. The following refactoring
encapsulates markdown items into their own re-usable templates with
support for indenting and newlines.

Apart from that, the refactoring addresses and fixes the following
issues (most of them were spotted in #20):
* Adding severity/priority prefix to trigger prototypes
* Put trigger expression into code block.
  The trigger (prototype) expressions might span over multiple lines,
  which breaks the formatting. Moving them from an inline code block to a
  standalone code block should take care of this, and enhance the
  readability.
* Fixing Discovery heading
  The Discovery heading was broken as it lacked a newline