### PR TITLE
Fix make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,14 +110,11 @@ install-app-selinux:
 	)
 	install -p -m 644 rabe.lst  $(SELINUXDIR)/targeted
 
-# install a userparameters config file per app that matches the <app>.conf config file naming policy
-# allowed to fail for apps without such a config
+# install a userparameters config file per app that matches the *.conf files
 .PHONY: install-app-config
 install-app-config:
 	install -d $(AGENTDDIR)
-	$(foreach app,$(APPS), \
-	    install -p -m 644 app/$(app)/userparameters/*$(app).conf $(AGENTDDIR) || :; \
-	)
+	install -p -m 644 app/*/userparameters/*.conf $(AGENTDDIR)
 
 # install any scripts found in a */scripts/* subdir
 # they all get put into /var/libexec/zabbix/rabe and you need to take care not to 

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,8 @@ build-app-selinux:
 # in a SELinux module name of rabezbx<app>
 	$(foreach teFile,$(wildcard app/*/selinux/rabezbx*.te), \
 		make -C $(dir $(teFile)) -f $(SELINUX_MAKEFILE) \
-			PREFIX=/usr NAME=$(notdir $(basename $(teFile))) && \
-			echo -n "$(notdir $(basename $(teFile))) " >> rabe.lst; \
+			PREFIX=/usr NAME=$(notdir $(basename $(teFile))) \
+		&& echo -n "$(notdir $(basename $(teFile))) " >> rabe.lst; \
 	)
 
 .PHONY: build-app

--- a/Makefile
+++ b/Makefile
@@ -115,14 +115,14 @@ install-app-config:
 	install -p -m 644 app/*/userparameters/*.conf $(AGENTDDIR)
 
 # install any scripts found in a */scripts/* subdir
-# they all get put into /var/libexec/zabbix/rabe and you need to take care not to 
-# clash with existing scripts when adding new ones
+# they all get put into /var/libexec/zabbix/rabe and you need to take care not
+# to clash with existing scripts when adding new ones
 .PHONY: install-scripts
 install-scripts:
 	install -d $(AGENTEXECDIR)
-	for script in `find -path '*/scripts/*' -type f`; do \
-	    install -p -m 755 $$script $(AGENTEXECDIR); \
-	done
+	$(foreach script,$(wildcard */*/scripts/*), \
+		install -p -m 755 $(script) $(AGENTEXECDIR); \
+	)
 
 # install sudoers config droplets per app that matches the sudoers.d file
 # naming policy prefix


### PR DESCRIPTION
This PR fixes the `install-app-config`, `build-app-selinux` and `install-app-selinux` Makefile targets, which are currently broken due to fact that we've missed to address those during the naming convention update (#19 and #15).

Additionally, install commands are now installing only existing files and won't need any special failure treatments (such as `install ... || :;`) any more.

All in all this PR enables us to have a working RPM package again to install our Zabbix stuff.