### PR TITLE
Feature - IPMI power supply generic sensors

### DIFF
--- a/ipmi/Power_Supply_Generic_Sensors/README.md
+++ b/ipmi/Power_Supply_Generic_Sensors/README.md
@@ -1,0 +1,53 @@
+# Zabbix Power Supply Generic Sensors monitoring
+Monitoring of auto-discovered IPMI power supplies sensors (sensor type code
+`08h`) with generic 'digital' discrete values (reading type code `03h`).
+
+An external script is used for low-level discovery of the sensors (as Zabbix currently lacks LLD of IPMI sensors).
+
+## Usage
+1. Install the [IPMI sensor discovery script](../Sensor_Discovery).
+2. Import the
+   [`Template_IPMI_Power_Supply_Generic_Sensors.xml`](Template_IPMI_Power_Supply_Generic_Sensors.xml)
+   into your Zabbix server.
+3. Add the template to your host (or stack template)
+4. Set the following user macros on your host or template (those are required
+   for the auto discovery to work)
+   * `{$HOST.IPMI.CONN}` IP address or domain name of your IPMI host
+   * `{$HOST.IPMI.USER}` IPMI user
+   * `{$HOST.IPMI.PASS}` IPMI password
+5. Add an IPMI interface to your host
+6. Configure the IPMI parameters of your host
+7. Check if new data arrives
+
+This template is part of [RaBe's Zabbix template and helpers
+collection](https://github.com/radiorabe/rabe-zabbix).
+## Template IPMI Power Supply Generic Sensors
+IPMI template for power supplies sensors (sensor type code `08h`) with generic 'digital' discrete values (reading type code `03h`).
+
+The `{$HOST.IPMI.CONN}`, `{$HOST.IPMI.USER}` and `{$HOST.IPMI.PASS}` macros have to be set according to your IPMI configuration.
+### Macros
+* `{$HOST.IPMI.CONN}` (default: localhost)
+* `{$HOST.IPMI.PASS}` (default: password)
+* `{$HOST.IPMI.USER}` (default: admin)
+* `{$IPMI_POWER_SUPPLY_SENSOR_TYPES}` (default: Power_Supply)
+### Discovery
+#### Power supply IPMI sensor discovery (`ipmi-sensor-discovery.sh["{$HOST.IPMI.CONN}","{$HOST.IPMI.USER}","{$HOST.IPMI.PASS}", "{$IPMI_POWER_SUPPLY_SENSOR_TYPES}"]`)
+Discovers power supply IPMI sensors with the help of the external ipmi-sensor-discovery.sh script.
+##### Item Prototypes
+* Sensor $2 (`ipmi.discrete-generic-sensor[power-supply,{#IPMI_SENSOR_NAME}]`)  
+  IPMI generic 'digital' discrete sensor prototype item for a power supply (sensor type code 08h, reading type code 03h).
+##### Trigger Prototypes
+* Warning: Power supply {#IPMI_SENSOR_NAME} is in warning state on {HOST.NAME}
+  ```
+  {Template IPMI Power Supply Generic Sensors:ipmi.discrete-generic-sensor[power-supply,{#IPMI_SENSOR_NAME}].band(#1,2)}=2
+  ```
+  The IPMI power supply 'digital' generic sensor (sensor
+type code 08h) is in "State Asserted" (sensor specific offset 01h) state. The second least significant bit = 1 (VALUE & 10 = 10).
+
+## License
+This template is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, version 3 of the License.
+
+## Copyright
+Copyright (c) 2017 [Radio Bern RaBe](http://www.rabe.ch)

--- a/ipmi/Power_Supply_Generic_Sensors/Template_IPMI_Power_Supply_Generic_Sensors.xml
+++ b/ipmi/Power_Supply_Generic_Sensors/Template_IPMI_Power_Supply_Generic_Sensors.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>3.0</version>
+    <date>2017-12-28T10:58:05Z</date>
+    <groups>
+        <group>
+            <name>IPMI templates</name>
+        </group>
+    </groups>
+    <templates>
+        <template>
+            <template>Template IPMI Power Supply Generic Sensors</template>
+            <name>Template IPMI Power Supply Generic Sensors</name>
+            <description>IPMI template for power supplies sensors (sensor type code `08h`) with generic 'digital' discrete values (reading type code `03h`).&#13;
+&#13;
+The `{$HOST.IPMI.CONN}`, `{$HOST.IPMI.USER}` and `{$HOST.IPMI.PASS}` macros have to be set according to your IPMI configuration.</description>
+            <groups>
+                <group>
+                    <name>IPMI templates</name>
+                </group>
+            </groups>
+            <applications/>
+            <items/>
+            <discovery_rules>
+                <discovery_rule>
+                    <name>Power supply IPMI sensor discovery</name>
+                    <type>10</type>
+                    <snmp_community/>
+                    <snmp_oid/>
+                    <key>ipmi-sensor-discovery.sh[&quot;{$HOST.IPMI.CONN}&quot;,&quot;{$HOST.IPMI.USER}&quot;,&quot;{$HOST.IPMI.PASS}&quot;, &quot;{$IPMI_POWER_SUPPLY_SENSOR_TYPES}&quot;]</key>
+                    <delay>1800</delay>
+                    <status>0</status>
+                    <allowed_hosts/>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <filter>
+                        <evaltype>0</evaltype>
+                        <formula/>
+                        <conditions/>
+                    </filter>
+                    <lifetime>7</lifetime>
+                    <description>Discovers power supply IPMI sensors with the help of the external ipmi-sensor-discovery.sh script.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>Sensor $2</name>
+                            <type>12</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>ipmi.discrete-generic-sensor[power-supply,{#IPMI_SENSOR_NAME}]</key>
+                            <delay>300</delay>
+                            <history>90</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor>{#IPMI_SENSOR_NAME}</ipmi_sensor>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>IPMI generic 'digital' discrete sensor prototype item for a power supply (sensor type code 08h, reading type code 03h).</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>IPMI - {#IPMI_SENSOR_TYPE}</name>
+                                </application_prototype>
+                            </application_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes>
+                        <trigger_prototype>
+                            <expression>{Template IPMI Power Supply Generic Sensors:ipmi.discrete-generic-sensor[power-supply,{#IPMI_SENSOR_NAME}].band(#1,2)}=2</expression>
+                            <name>Power supply {#IPMI_SENSOR_NAME} is in warning state on {HOST.NAME}</name>
+                            <url/>
+                            <status>0</status>
+                            <priority>2</priority>
+                            <description>The IPMI power supply 'digital' generic sensor (sensor&#13;
+type code 08h) is in &quot;State Asserted&quot; (sensor specific offset 01h) state. The second least significant bit = 1 (VALUE &amp; 10 = 10).</description>
+                            <type>0</type>
+                            <dependencies/>
+                        </trigger_prototype>
+                    </trigger_prototypes>
+                    <graph_prototypes/>
+                    <host_prototypes/>
+                </discovery_rule>
+            </discovery_rules>
+            <macros>
+                <macro>
+                    <macro>{$HOST.IPMI.CONN}</macro>
+                    <value>localhost</value>
+                </macro>
+                <macro>
+                    <macro>{$HOST.IPMI.PASS}</macro>
+                    <value>password</value>
+                </macro>
+                <macro>
+                    <macro>{$HOST.IPMI.USER}</macro>
+                    <value>admin</value>
+                </macro>
+                <macro>
+                    <macro>{$IPMI_POWER_SUPPLY_SENSOR_TYPES}</macro>
+                    <value>Power_Supply</value>
+                </macro>
+            </macros>
+            <templates/>
+            <screens/>
+        </template>
+    </templates>
+</zabbix_export>

--- a/ipmi/Power_Supply_Generic_Sensors/doc/README.head.md
+++ b/ipmi/Power_Supply_Generic_Sensors/doc/README.head.md
@@ -1,0 +1,20 @@
+Monitoring of auto-discovered IPMI power supplies sensors (sensor type code
+`08h`) with generic 'digital' discrete values (reading type code `03h`).
+
+An external script is used for low-level discovery of the sensors (as Zabbix currently lacks LLD of IPMI sensors).
+
+## Usage
+1. Install the [IPMI sensor discovery script](../Sensor_Discovery).
+2. Import the
+   [`Template_IPMI_Power_Supply_Generic_Sensors.xml`](Template_IPMI_Power_Supply_Generic_Sensors.xml)
+   into your Zabbix server.
+3. Add the template to your host (or stack template)
+4. Set the following user macros on your host or template (those are required
+   for the auto discovery to work)
+   * `{$HOST.IPMI.CONN}` IP address or domain name of your IPMI host
+   * `{$HOST.IPMI.USER}` IPMI user
+   * `{$HOST.IPMI.PASS}` IPMI password
+5. Add an IPMI interface to your host
+6. Configure the IPMI parameters of your host
+7. Check if new data arrives
+


### PR DESCRIPTION
Monitoring of auto-discovered IPMI power supplies sensors (sensor type code `08h`) with generic 'digital' discrete values (reading type code `03h`).

