### PR TITLE
Netgear Switching: Spanning tree protocol support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,7 @@ SNMPS            := $(filter-out README.md \
 								 SNMPv2_Interfaces_HC \
 								 SNMPv2_Netgear_Box_Services \
 								 SNMPv2_Netgear_Inventory \
-								 SNMPv2_Netgear_SNTP_client \
-								 SNMPv2_Netgear_Switching, $(SNMPS))
+								 SNMPv2_Netgear_SNTP_client, $(SNMPS))
 
 update-app-doc:
 	$(foreach app,$(APPS), \

--- a/snmp/SNMPv2_Netgear_Switching/README.md
+++ b/snmp/SNMPv2_Netgear_Switching/README.md
@@ -1,50 +1,39 @@
-# Zabbix SNMPv2 Netgear Switching template
-Monitors Netgear Switching parameters (fastPathSwitching), currently only CPU and memory exposed by the NETGEAR-SWITCHING-MIB via SNMPv2.
-
-This template is part of [RaBe's Zabbix template and helpers
-collection](https://github.com/radiorabe/rabe-zabbix).
-
-## Features
-* Well, not that much. It supports only CPU and memory parameters at the moment.
-* Uses macros for trigger thresholds which can be easily adapted.
-
-## Items
-* Total memory
-* Free memory
-* Total CPU utilization
-
-## Triggers
-* High: Free memory is very low (< 5%)
-* Warning: Free memory is low (< 10%)
-
-## Graphs
-* Free memory statistics
-
-## Macros
-* <code>{$SNMP_COMMUNITY}</code>
-
-  SNMPv2 community which defaults to <code>public</code>
-
-* <code>{$SNMPV2_NETGEAR_SWITCHING_MEMORY_PFREE_HIGH_THRESHOLD}</code>
-
-  Free memory in percent for HIGH trigger (5% per default)
-
-* <code>{$SNMPV2_NETGEAR_SWITCHING_MEMORY_PFREE_WARNING_THRESHOLD}</code>
-
-  Free memory in percent for WARNING trigger (10% per default)
-
-
-## Requirements
-* [Zabbix](https://www.zabbix.com/) >= 3.0
-* Your host must support SNMPv2
-* NETGEAR-SWITCHING-MIB and its dependencies must be available and accessible by the Zabbix server (should be present within the MIB package of your Netgear device)
+# Zabbix SNMPv2 Netgear Switching monitoring
+Monitors Netgear Switching parameters (fastPathSwitching), currently only CPU,
+memory and spanning tree protocol information exposed by the
+NETGEAR-SWITCHING-MIB via SNMPv2.
 
 ## Usage
-1. Import the [Template_SNMPv2_Netgear_Switching.xml](Template_SNMPv2_Netgear_Switching.xml) into your Zabbix server.
-2. Add the template to your host (or stack template)
-3. Add an SNMP interface configuration to your host
-4. Set the <code>{$SNMP_COMMUNITY}</code> macro to your desired community if you don't use <code>public</code>
-5. Check if new data arrives
+1. Download the NETGEAR-SWITCHING-MIB and its dependencies (should be present
+   within the MIB package of your Netgear device) 
+2. Place the MIB file(s) into your default MIB directory on the Zabbix server
+   and/or proxy (usually `/usr/local/share/snmp/mibs`) and make sure that the
+   Zabbix server and/or proxy loads them (see [Using and loading
+   MIBs](http://www.net-snmp.org/wiki/index.php/TUT:Using_and_loading_MIBS)).
+3. Import the
+   [`Template_SNMPv2_Netgear_Switching.xml`](Template_SNMPv2_Netgear_Switching.xml)
+   into your Zabbix server (click on the `Raw` button to download).
+4. Add an SNMP interface configuration to your host
+5. Set the `{$SNMP_COMMUNITY}` macro to your desired community if you don't use
+   `public`
+6. Add the template to your host (or stack template)
+7. Check if new data arrives
+
+## Notes
+### snmpwalk command
+The following `snmpwalk` command might be helpful for debugging:
+```bash
+snmpwalk -v 2c -c public <HOST> NETGEAR-SWITCHING-MIB::fastPathSwitching
+```
+
+## CPU utilization
+The CPU utilization is currently only available as a string with 5, 60 and 300
+second values (`5 Secs ( 13.2483%)   60 Secs ( 11.3541%)  300 Secs (11.2930%)`
+which makes it very hard or impossible to create triggers.
+
+Please open up an issue if you know of an elegant way to either parse and split
+the item into separate float items or if you find other OIDs which separately
+expose the values - thanks.
 
 ## Related templates
 * [SNMPv2 Generic](../SNMPv2_Generic)
@@ -53,26 +42,88 @@ collection](https://github.com/radiorabe/rabe-zabbix).
 * [SNMPv2 Netgear Inventory](../SNMPv2_Netgear_Inventory)
 * [SNMPv2 Netgear SNTP Client](../SNMPv2_Netgear_SNTP_CLIENT)
 
-# Notes
-## snmpwalk command
-The following <code>snmpwalk</code> command might be helpful for debugging:
-```bash
-snmpwalk -v 2c -c public <HOST> NETGEAR-SWITCHING-MIB::fastPathSwitching
-```
+This template is part of [RaBe's Zabbix template and helpers
+collection](https://github.com/radiorabe/rabe-zabbix).
+## Template SNMPv2 Netgear Switching
+Template for Netgear Private MIB for FastPath Switching based on NETGEAR-SWITCHING-MIB
+### Items
+* STP admin mode (`agentStpAdminMode[]`)  
+  The spanning tree operational status
+* STP CIST bridge forward delay (`agentStpCstBridgeFwdDelay[]`)  
+  The MSTP bridge forward delay for the CIST.
+* STP CIST bridge hello time (`agentStpCstBridgeHelloTime[]`)  
+  The MSTP bridge hello time for the CIST.
+* STP CIST bridge hold count (`agentStpCstBridgeHoldCount[]`)  
+  The MSTP bridge hold count for the CIST. The value of maximum bpdus that a bridge is allowed to send within a hello time window.
+* STP CIST bridge hold time (`agentStpCstBridgeHoldTime[]`)  
+  The MSTP bridge hold time for the CIST.
+* STP CIST bridge max age (`agentStpCstBridgeMaxAge[]`)  
+  The MSTP bridge max age for the CIST.
+* STP CIST bridge max hops (`agentStpCstBridgeMaxHops[]`)  
+  The MSTP bridge max hops for the CIST.
+* STP CIST bridge priority (`agentStpCstBridgePriority[]`)  
+  The MSTP bridge priority for the CIST.
+* STP CIST root port hello time (`agentStpCstHelloTime[]`)  
+  The MSTP root port hello time for the CIST.
+* STP CIST root port max age (`agentStpCstMaxAge[]`)  
+  The MSTP root port max age for the CIST.
+* STP CIST regional root ID (`agentStpCstRegionalRootId[]`)  
+  The MSTP regional root identifier for the CIST.
+* STP CIST regional root path cost (`agentStpCstRegionalRootPathCost[]`)  
+  The MSTP regional root path cost for the CIST.
+* STP CIST root port forward delay (`agentStpCstRootFwdDelay[]`)  
+  The MSTP root port forward delay for the CIST.
+* STP protocol version (`agentStpForceVersion[]`)  
+  The MST configuration force protocol version.
+* Total memory (`agentSwitchCpuProcessMemAvailable[]`)  
+  The total memory available in KBytes.
+* Free memory (`agentSwitchCpuProcessMemFree[]`)  
+  The total memory free for utilization in KBytes.
+* Total CPU utilization (`agentSwitchCpuProcessTotalUtilization[]`)  
+  Total CPU utilization over a period of 5, 60, 300 seconds, and the Rising threshold period also in seconds, if configured.
+### Macros
+* `{$SNMPV2_NETGEAR_SWITCHING_MEMORY_PFREE_HIGH_THRESHOLD}` (default: 5)
+* `{$SNMPV2_NETGEAR_SWITCHING_MEMORY_PFREE_WARNING_THRESHOLD}` (default: 10)
+### Discovery
+#### Multiple spanning tree protocol instances (`agentStpMstId.discovery`)
+Discovery of multiple spanning tree protocol instances (STP MST), including the common and internal spanning tree instance 0.
+##### Item Prototypes
+* MSTP bridge identifier of instance $1 (`agentStpMstBridgeIdentifier[{#NETGEAR_SWITCHING_STP_MST_ID}]`)  
+  The MSTP bridge identifier in a specific instance.
+* MSTP bridge priority of instance $1 (`agentStpMstBridgePriority[{#NETGEAR_SWITCHING_STP_MST_ID}]`)  
+  The MSTP bridge priority in a specific instance. The priority is in the increments of 4096. The recommended default value is 32768.
+* MSTP designated root bridge identifier of instance $1 (`agentStpMstDesignatedRootId[{#NETGEAR_SWITCHING_STP_MST_ID}]`)  
+  The MSTP designated root bridge identifier in a specific instance.
+* MSTP root path cost of instance $1 (`agentStpMstRootPathCost[{#NETGEAR_SWITCHING_STP_MST_ID}]`)  
+  The MSTP root path cost in a specific instance.
+* MSTP designated root port ID of instance $1 (`agentStpMstRootPortId[{#NETGEAR_SWITCHING_STP_MST_ID}]`)  
+  The MSTP root port ID in a specific instance.
+* MSTP time since the last topology change of instance $1 (`agentStpMstTimeSinceTopologyChange[{#NETGEAR_SWITCHING_STP_MST_ID}]`)  
+  The MSTP time since the last topology change in a specific instance.
+* MSTP count of topology changes of instance $1 (`agentStpMstTopologyChangeCount[{#NETGEAR_SWITCHING_STP_MST_ID}]`)  
+  The MSTP count of topology changes in a specific instance.
+##### Trigger Prototypes
+* Warning: Recent spanning tree topology change on MST instance {#NETGEAR_SWITCHING_STP_MST_ID} on {HOST.NAME}
+  ```
+  {Template SNMPv2 Netgear Switching:agentStpMstTimeSinceTopologyChange[{#NETGEAR_SWITCHING_STP_MST_ID}].last()}<900
+  ```
+  There was a spanning tree topology change on the multiple spanning tree instance `{#NETGEAR_SWITCHING_STP_MST_ID}` during the last 15 minutes.
+### Triggers
+* Warning: Free memory on {HOST.NAME} is low (< $2 %, {ITEM.VALUE2} available)
+  ```
+  100 / {Template SNMPv2 Netgear Switching:agentSwitchCpuProcessMemAvailable[].last()} *
+  {Template SNMPv2 Netgear Switching:agentSwitchCpuProcessMemFree[].last()} < {$SNMPV2_NETGEAR_SWITCHING_MEMORY_PFREE_WARNING_THRESHOLD}
+  ```
+* High: Free memory on {HOST.NAME} is very low (< $2 %, {ITEM.VALUE2} available)
+  ```
+  100 / {Template SNMPv2 Netgear Switching:agentSwitchCpuProcessMemAvailable[].last()} *
+  {Template SNMPv2 Netgear Switching:agentSwitchCpuProcessMemFree[].last()} < {$SNMPV2_NETGEAR_SWITCHING_MEMORY_PFREE_HIGH_THRESHOLD}
+  ```
 
-## CPU utilization
-The CPU utilization is currently only available as a string with 5, 60 and 300
-second values (<code>5 Secs ( 13.2483%)   60 Secs ( 11.3541%)  300 Secs (11.2930%)</code>
-which makes it very hard or impossible to create triggers.
-
-Please open up an issue if you know of an elegant way to either parse and split
-the item into separate float items or if you find other OIDs which separately
-expose the values - thanks.
-
-# License
+## License
 This template is free software: you can redistribute it and/or modify it under
 the terms of the GNU Affero General Public License as published by the Free
 Software Foundation, version 3 of the License.
 
-# Copyright
-Copyright (c) 2017 [Radio Bern RaBe](http://www.rabe.ch)
+## Copyright
+Copyright (c) 2017 - 2018 [Radio Bern RaBe](http://www.rabe.ch)

--- a/snmp/SNMPv2_Netgear_Switching/Template_SNMPv2_Netgear_Switching.xml
+++ b/snmp/SNMPv2_Netgear_Switching/Template_SNMPv2_Netgear_Switching.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.0</version>
-    <date>2017-02-03T09:21:50Z</date>
+    <date>2018-12-28T17:13:08Z</date>
     <groups>
         <group>
             <name>SNMP templates</name>
@@ -11,7 +11,7 @@
         <template>
             <template>Template SNMPv2 Netgear Switching</template>
             <name>Template SNMPv2 Netgear Switching</name>
-            <description>Templeate for Netgear Private MIB for FastPath Switching based on NETGEAR-SWITCHING-MIB</description>
+            <description>Template for Netgear Private MIB for FastPath Switching based on NETGEAR-SWITCHING-MIB</description>
             <groups>
                 <group>
                     <name>SNMP templates</name>
@@ -21,8 +21,620 @@
                 <application>
                     <name>SNMPv2 Netgear Switching</name>
                 </application>
+                <application>
+                    <name>SNMPv2 Netgear Switching - Spanning Tree Protocol</name>
+                </application>
+                <application>
+                    <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                </application>
             </applications>
             <items>
+                <item>
+                    <name>STP admin mode</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpAdminMode.0</snmp_oid>
+                    <key>agentStpAdminMode[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>30</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The spanning tree operational status</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>Netgear Spanning Tree Admin Mode</name>
+                    </valuemap>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST bridge forward delay</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstBridgeFwdDelay.0</snmp_oid>
+                    <key>agentStpCstBridgeFwdDelay[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>90</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>s</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP bridge forward delay for the CIST.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST bridge hello time</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstBridgeHelloTime.0</snmp_oid>
+                    <key>agentStpCstBridgeHelloTime[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>90</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>s</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP bridge hello time for the CIST.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST bridge hold count</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstBridgeHoldCount.0</snmp_oid>
+                    <key>agentStpCstBridgeHoldCount[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>90</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP bridge hold count for the CIST. The value of maximum bpdus that a bridge is allowed to send within a hello time window.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST bridge hold time</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstBridgeHoldTime.0</snmp_oid>
+                    <key>agentStpCstBridgeHoldTime[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>90</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>s</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP bridge hold time for the CIST.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST bridge max age</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstBridgeMaxAge.0</snmp_oid>
+                    <key>agentStpCstBridgeMaxAge[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>90</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>s</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP bridge max age for the CIST.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST bridge max hops</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstBridgeMaxHops.0</snmp_oid>
+                    <key>agentStpCstBridgeMaxHops[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>90</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP bridge max hops for the CIST.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST bridge priority</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstBridgePriority.0</snmp_oid>
+                    <key>agentStpCstBridgePriority[]</key>
+                    <delay>300</delay>
+                    <history>30</history>
+                    <trends>90</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP bridge priority for the CIST.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST root port hello time</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstHelloTime.0</snmp_oid>
+                    <key>agentStpCstHelloTime[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>90</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>s</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP root port hello time for the CIST.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST root port max age</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstMaxAge.0</snmp_oid>
+                    <key>agentStpCstMaxAge[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>90</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>s</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP root port max age for the CIST.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST regional root ID</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstRegionalRootId.0</snmp_oid>
+                    <key>agentStpCstRegionalRootId[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>0</trends>
+                    <status>0</status>
+                    <value_type>1</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP regional root identifier for the CIST.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST regional root path cost</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstRegionalRootPathCost.0</snmp_oid>
+                    <key>agentStpCstRegionalRootPathCost[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>90</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP regional root path cost for the CIST.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP CIST root port forward delay</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpCstRootFwdDelay.0</snmp_oid>
+                    <key>agentStpCstRootFwdDelay[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>90</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units>s</units>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MSTP root port forward delay for the CIST.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - Common and internal</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>STP protocol version</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <multiplier>0</multiplier>
+                    <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpForceVersion.0</snmp_oid>
+                    <key>agentStpForceVersion[]</key>
+                    <delay>300</delay>
+                    <history>7</history>
+                    <trends>30</trends>
+                    <status>0</status>
+                    <value_type>3</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description>The MST configuration force protocol version.</description>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>SNMPv2 Netgear Switching - Spanning Tree Protocol</name>
+                        </application>
+                    </applications>
+                    <valuemap>
+                        <name>Netgear Spanning Tree Protocol Version</name>
+                    </valuemap>
+                    <logtimefmt/>
+                </item>
                 <item>
                     <name>Total memory</name>
                     <type>4</type>
@@ -153,7 +765,365 @@
                     <logtimefmt/>
                 </item>
             </items>
-            <discovery_rules/>
+            <discovery_rules>
+                <discovery_rule>
+                    <name>Multiple spanning tree protocol instances</name>
+                    <type>4</type>
+                    <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                    <snmp_oid>discovery[{#NETGEAR_SWITCHING_STP_MST_ID},NETGEAR-SWITCHING-MIB::agentStpMstId]</snmp_oid>
+                    <key>agentStpMstId.discovery</key>
+                    <delay>300</delay>
+                    <status>0</status>
+                    <allowed_hosts/>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <filter>
+                        <evaltype>0</evaltype>
+                        <formula/>
+                        <conditions/>
+                    </filter>
+                    <lifetime>30</lifetime>
+                    <description>Discovery of multiple spanning tree protocol instances (STP MST), including the common and internal spanning tree instance 0.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <name>MSTP bridge identifier of instance $1</name>
+                            <type>4</type>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                            <multiplier>0</multiplier>
+                            <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpMstBridgeIdentifier.{#SNMPINDEX}</snmp_oid>
+                            <key>agentStpMstBridgeIdentifier[{#NETGEAR_SWITCHING_STP_MST_ID}]</key>
+                            <delay>300</delay>
+                            <history>7</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>1</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>The MSTP bridge identifier in a specific instance.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - MST instance {#NETGEAR_SWITCHING_STP_MST_ID}</name>
+                                </application_prototype>
+                            </application_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>MSTP bridge priority of instance $1</name>
+                            <type>4</type>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                            <multiplier>0</multiplier>
+                            <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpMstBridgePriority.{#SNMPINDEX}</snmp_oid>
+                            <key>agentStpMstBridgePriority[{#NETGEAR_SWITCHING_STP_MST_ID}]</key>
+                            <delay>300</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>The MSTP bridge priority in a specific instance. The priority is in the increments of 4096. The recommended default value is 32768.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - MST instance {#NETGEAR_SWITCHING_STP_MST_ID}</name>
+                                </application_prototype>
+                            </application_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>MSTP designated root bridge identifier of instance $1</name>
+                            <type>4</type>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                            <multiplier>0</multiplier>
+                            <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpMstDesignatedRootId.{#SNMPINDEX}</snmp_oid>
+                            <key>agentStpMstDesignatedRootId[{#NETGEAR_SWITCHING_STP_MST_ID}]</key>
+                            <delay>300</delay>
+                            <history>30</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>1</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>The MSTP designated root bridge identifier in a specific instance.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - MST instance {#NETGEAR_SWITCHING_STP_MST_ID}</name>
+                                </application_prototype>
+                            </application_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>MSTP root path cost of instance $1</name>
+                            <type>4</type>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                            <multiplier>0</multiplier>
+                            <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpMstRootPathCost.{#SNMPINDEX}</snmp_oid>
+                            <key>agentStpMstRootPathCost[{#NETGEAR_SWITCHING_STP_MST_ID}]</key>
+                            <delay>300</delay>
+                            <history>7</history>
+                            <trends>30</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>The MSTP root path cost in a specific instance.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - MST instance {#NETGEAR_SWITCHING_STP_MST_ID}</name>
+                                </application_prototype>
+                            </application_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>MSTP designated root port ID of instance $1</name>
+                            <type>4</type>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                            <multiplier>0</multiplier>
+                            <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpMstRootPortId.{#SNMPINDEX}</snmp_oid>
+                            <key>agentStpMstRootPortId[{#NETGEAR_SWITCHING_STP_MST_ID}]</key>
+                            <delay>300</delay>
+                            <history>30</history>
+                            <trends>0</trends>
+                            <status>0</status>
+                            <value_type>1</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>The MSTP root port ID in a specific instance.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - MST instance {#NETGEAR_SWITCHING_STP_MST_ID}</name>
+                                </application_prototype>
+                            </application_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>MSTP time since the last topology change of instance $1</name>
+                            <type>4</type>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                            <multiplier>1</multiplier>
+                            <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpMstTimeSinceTopologyChange.{#SNMPINDEX}</snmp_oid>
+                            <key>agentStpMstTimeSinceTopologyChange[{#NETGEAR_SWITCHING_STP_MST_ID}]</key>
+                            <delay>300</delay>
+                            <history>90</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>uptime</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>0.01</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>The MSTP time since the last topology change in a specific instance.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - MST instance {#NETGEAR_SWITCHING_STP_MST_ID}</name>
+                                </application_prototype>
+                            </application_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>MSTP count of topology changes of instance $1</name>
+                            <type>4</type>
+                            <snmp_community>{$SNMP_COMMUNITY}</snmp_community>
+                            <multiplier>0</multiplier>
+                            <snmp_oid>NETGEAR-SWITCHING-MIB::agentStpMstTopologyChangeCount.{#SNMPINDEX}</snmp_oid>
+                            <key>agentStpMstTopologyChangeCount[{#NETGEAR_SWITCHING_STP_MST_ID}]</key>
+                            <delay>300</delay>
+                            <history>30</history>
+                            <trends>90</trends>
+                            <status>0</status>
+                            <value_type>3</value_type>
+                            <allowed_hosts/>
+                            <units/>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description>The MSTP count of topology changes in a specific instance.</description>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes>
+                                <application_prototype>
+                                    <name>SNMPv2 Netgear Switching - Spanning Tree Protocol - MST instance {#NETGEAR_SWITCHING_STP_MST_ID}</name>
+                                </application_prototype>
+                            </application_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes>
+                        <trigger_prototype>
+                            <expression>{Template SNMPv2 Netgear Switching:agentStpMstTimeSinceTopologyChange[{#NETGEAR_SWITCHING_STP_MST_ID}].last()}&lt;900</expression>
+                            <name>Recent spanning tree topology change on MST instance {#NETGEAR_SWITCHING_STP_MST_ID} on {HOST.NAME}</name>
+                            <url/>
+                            <status>0</status>
+                            <priority>2</priority>
+                            <description>There was a spanning tree topology change on the multiple spanning tree instance `{#NETGEAR_SWITCHING_STP_MST_ID}` during the last 15 minutes.</description>
+                            <type>0</type>
+                            <dependencies/>
+                        </trigger_prototype>
+                    </trigger_prototypes>
+                    <graph_prototypes/>
+                    <host_prototypes/>
+                </discovery_rule>
+            </discovery_rules>
             <macros>
                 <macro>
                     <macro>{$SNMPV2_NETGEAR_SWITCHING_MEMORY_PFREE_HIGH_THRESHOLD}</macro>
@@ -235,4 +1205,36 @@
             </graph_items>
         </graph>
     </graphs>
+    <value_maps>
+        <value_map>
+            <name>Netgear Spanning Tree Admin Mode</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>enable</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>disable</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+        <value_map>
+            <name>Netgear Spanning Tree Protocol Version</name>
+            <mappings>
+                <mapping>
+                    <value>1</value>
+                    <newvalue>dot1d</newvalue>
+                </mapping>
+                <mapping>
+                    <value>2</value>
+                    <newvalue>dot1w</newvalue>
+                </mapping>
+                <mapping>
+                    <value>3</value>
+                    <newvalue>dot1s</newvalue>
+                </mapping>
+            </mappings>
+        </value_map>
+    </value_maps>
 </zabbix_export>

--- a/snmp/SNMPv2_Netgear_Switching/doc/README.head.md
+++ b/snmp/SNMPv2_Netgear_Switching/doc/README.head.md
@@ -1,0 +1,42 @@
+Monitors Netgear Switching parameters (fastPathSwitching), currently only CPU,
+memory and spanning tree protocol information exposed by the
+NETGEAR-SWITCHING-MIB via SNMPv2.
+
+## Usage
+1. Download the NETGEAR-SWITCHING-MIB and its dependencies (should be present
+   within the MIB package of your Netgear device) 
+2. Place the MIB file(s) into your default MIB directory on the Zabbix server
+   and/or proxy (usually `/usr/local/share/snmp/mibs`) and make sure that the
+   Zabbix server and/or proxy loads them (see [Using and loading
+   MIBs](http://www.net-snmp.org/wiki/index.php/TUT:Using_and_loading_MIBS)).
+3. Import the
+   [`Template_SNMPv2_Netgear_Switching.xml`](Template_SNMPv2_Netgear_Switching.xml)
+   into your Zabbix server (click on the `Raw` button to download).
+4. Add an SNMP interface configuration to your host
+5. Set the `{$SNMP_COMMUNITY}` macro to your desired community if you don't use
+   `public`
+6. Add the template to your host (or stack template)
+7. Check if new data arrives
+
+## Notes
+### snmpwalk command
+The following `snmpwalk` command might be helpful for debugging:
+```bash
+snmpwalk -v 2c -c public <HOST> NETGEAR-SWITCHING-MIB::fastPathSwitching
+```
+
+## CPU utilization
+The CPU utilization is currently only available as a string with 5, 60 and 300
+second values (`5 Secs ( 13.2483%)   60 Secs ( 11.3541%)  300 Secs (11.2930%)`
+which makes it very hard or impossible to create triggers.
+
+Please open up an issue if you know of an elegant way to either parse and split
+the item into separate float items or if you find other OIDs which separately
+expose the values - thanks.
+
+## Related templates
+* [SNMPv2 Generic](../SNMPv2_Generic)
+* [SNMPv2 Interface HC](../SNMPv2_Interface_HC)
+* [SNMPv2 Netgear Box Services](../SNMPv2_Netgear_Box_Services)
+* [SNMPv2 Netgear Inventory](../SNMPv2_Netgear_Inventory)
+* [SNMPv2 Netgear SNTP Client](../SNMPv2_Netgear_SNTP_CLIENT)


### PR DESCRIPTION
The following PR adds spanning tree protocol support to the existing SNMPv2 Netgear Switching template. Apart from the new items, triggers and discovery rule, the PR also switches from manual to auto generated documentation extraction out of the template.