### PR TITLE
[Zabbix Agent] allow sudo access in selinux

### DIFF
--- a/app/zabbix-agent/selinux/rabezbxzabbixagent.te
+++ b/app/zabbix-agent/selinux/rabezbxzabbixagent.te
@@ -2,8 +2,32 @@ module rabezbxzabbixagent 1.0;
 
 require {
     type zabbix_agent_t;
+    type chkpwd_exec_t;
+    type sssd_conf_t;
+    type shadow_t;
+    type system_dbusd_t;
     class process setrlimit;
+    class unix_stream_socket connectto;
+    class dbus send_msg;
+    class file { read open execute execute_no_trans };
+    class capability { dac_read_search };
 }
 
 #============= zabbix_agent_t ==============
+# zabbix wants to setrlimit for "security" reasons
 allow zabbix_agent_t self:process setrlimit;
+
+# basics needed for sudo to check the zabbix user
+allow zabbix_agent_t chkpwd_exec_t:file execute_no_trans;
+allow zabbix_agent_t shadow_t:file { read open };
+# this dac rule lets sudo check in the dac for (ie. pam_selinux)
+allow zabbix_agent_t self:capability { dac_read_search };
+# pam is configured with pam_sss at rabe
+allow zabbix_agent_t sssd_conf_t:file { read open };
+
+# agent may access system dbus, actual dbus requests get denied later,
+# mostly on the response level from where someone should be answering.
+# this is part of allowing sssd to operate in sudo but can also be
+# used elsewhere.
+allow zabbix_agent_t system_dbusd_t:unix_stream_socket connectto;
+allow zabbix_agent_t system_dbusd_t:dbus send_msg;


### PR DESCRIPTION
This lets the zabbix agent run commands through sudo without getting denied. After this I'm still seeing some `dac_override` denials they do not seem to impact anything and denying them is the sane thing to do.

Please see the diff for more on the changes. 

You can use `semanage permissive -d zabbix_agent_t` to clean up again after this is merged if you used the workaround from #75.

Fixes #75