### PR TITLE
fix(lvm): Add --nolocking to LVM commands

### DIFF
--- a/app/LVM/userparameters/rabe.lvm.conf
+++ b/app/LVM/userparameters/rabe.lvm.conf
@@ -48,7 +48,7 @@
 # sign escaping ($$1) in discovery rules as they normally would within user
 # parameters containing Zabbix positional references. In fact, it would break
 # the discovery rule.
-UserParameter=rabe.lvm.pvs.discovery,/usr/bin/sudo /sbin/pvs --noheadings --options pv_name,pv_uuid,pv_fmt 2>/dev/null | /usr/bin/awk 'BEGIN { printf "{\"data\":[" } { printf sep"{\"{#LVM_PV_NAME}\":\""$1"\","; printf "\"{#LVM_PV_UUID}\":\""$2"\","; printf "\"{#LVM_PV_TYPE}\":\""$3"\"}"; sep = "," } END { printf "]}" }'
+UserParameter=rabe.lvm.pvs.discovery,/usr/bin/sudo /sbin/pvs --noheadings --nolocking --options pv_name,pv_uuid,pv_fmt 2>/dev/null | /usr/bin/awk 'BEGIN { printf "{\"data\":[" } { printf sep"{\"{#LVM_PV_NAME}\":\""$1"\","; printf "\"{#LVM_PV_UUID}\":\""$2"\","; printf "\"{#LVM_PV_TYPE}\":\""$3"\"}"; sep = "," } END { printf "]}" }'
 
 
 #
@@ -77,7 +77,7 @@ UserParameter=rabe.lvm.pvs.discovery,/usr/bin/sudo /sbin/pvs --noheadings --opti
 # sign escaping ($$1) in discovery rules as they normally would within user
 # parameters containing Zabbix positional references. In fact, it would break
 # the discovery rule.
-UserParameter=rabe.lvm.vgs.discovery,/usr/bin/sudo /sbin/vgs --noheadings --options vg_name,vg_uuid,vg_fmt 2>/dev/null | /usr/bin/awk 'BEGIN { printf "{\"data\":[" } { printf sep"{\"{#LVM_VG_NAME}\":\""$1"\","; printf "\"{#LVM_VG_UUID}\":\""$2"\","; printf "\"{#LVM_VG_TYPE}\":\""$3"\"}"; sep = "," } END { printf "]}" }'
+UserParameter=rabe.lvm.vgs.discovery,/usr/bin/sudo /sbin/vgs --noheadings --nolocking --options vg_name,vg_uuid,vg_fmt 2>/dev/null | /usr/bin/awk 'BEGIN { printf "{\"data\":[" } { printf sep"{\"{#LVM_VG_NAME}\":\""$1"\","; printf "\"{#LVM_VG_UUID}\":\""$2"\","; printf "\"{#LVM_VG_TYPE}\":\""$3"\"}"; sep = "," } END { printf "]}" }'
 
 
 #
@@ -130,7 +130,7 @@ UserParameter=rabe.lvm.vgs.discovery,/usr/bin/sudo /sbin/vgs --noheadings --opti
 # Note, that the awk field parameters ($1 - $N) require double dollar sign
 # escaping ($$1) to prevent them from being interpreted as Zabbix positional
 # references.
-UserParameter=rabe.lvm.lvs.discovery[*],/usr/bin/sudo /sbin/lvs --noheadings --options lv_full_name,lv_uuid,segtype,lv_role,lv_name,vg_name,lv_path 2>/dev/null | /usr/bin/awk 'BEGIN { printf "{\"data\":[" } { printf sep"{\"{#LVM_LV_FULL_NAME}\":\""$$1"\","; printf "\"{#LVM_LV_UUID}\":\""$$2"\","; printf "\"{#LVM_LV_TYPE}\":\""$$3"\","; printf "\"{#LVM_LV_ROLE}\":\""$$4"\","; printf "\"{#LVM_LV_NAME}\":\""$$5"\","; printf "\"{#LVM_LV_VG_NAME}\":\""$$6"\","; printf "\"{#LVM_LV_PATH}\":\""$$7"\"}"; sep = "," } END { printf "]}" }'
+UserParameter=rabe.lvm.lvs.discovery[*],/usr/bin/sudo /sbin/lvs --noheadings --nolocking --options lv_full_name,lv_uuid,segtype,lv_role,lv_name,vg_name,lv_path 2>/dev/null | /usr/bin/awk 'BEGIN { printf "{\"data\":[" } { printf sep"{\"{#LVM_LV_FULL_NAME}\":\""$$1"\","; printf "\"{#LVM_LV_UUID}\":\""$$2"\","; printf "\"{#LVM_LV_TYPE}\":\""$$3"\","; printf "\"{#LVM_LV_ROLE}\":\""$$4"\","; printf "\"{#LVM_LV_NAME}\":\""$$5"\","; printf "\"{#LVM_LV_VG_NAME}\":\""$$6"\","; printf "\"{#LVM_LV_PATH}\":\""$$7"\"}"; sep = "," } END { printf "]}" }'
 
 
 #
@@ -147,7 +147,7 @@ UserParameter=rabe.lvm.lvs.discovery[*],/usr/bin/sudo /sbin/lvs --noheadings --o
 # Note, that the awk field parameters ($1 - $N) require double dollar sign
 # escaping ($$1) to prevent them from being interpreted as Zabbix positional
 # references.
-UserParameter=rabe.lvm.pvs.value[*],/usr/bin/sudo /sbin/pvs --noheadings --nosuffix --units b --options '$2' '$1' 2>/dev/null | /usr/bin/awk '{ print $$1 }'
+UserParameter=rabe.lvm.pvs.value[*],/usr/bin/sudo /sbin/pvs --noheadings --nolocking --nosuffix --units b --options '$2' '$1' 2>/dev/null | /usr/bin/awk '{ print $$1 }'
 
 
 #
@@ -164,7 +164,7 @@ UserParameter=rabe.lvm.pvs.value[*],/usr/bin/sudo /sbin/pvs --noheadings --nosuf
 # Note, that the awk field parameters ($1 - $N) require double dollar sign
 # escaping ($$1) to prevent them from being interpreted as Zabbix positional
 # references.
-UserParameter=rabe.lvm.vgs.value[*],/usr/bin/sudo /sbin/vgs --noheadings --nosuffix --units b --options '$2' '$1' 2>/dev/null | /usr/bin/awk '{ print $$1 }'
+UserParameter=rabe.lvm.vgs.value[*],/usr/bin/sudo /sbin/vgs --noheadings --nolocking --nosuffix --units b --options '$2' '$1' 2>/dev/null | /usr/bin/awk '{ print $$1 }'
 
 
 #
@@ -181,4 +181,4 @@ UserParameter=rabe.lvm.vgs.value[*],/usr/bin/sudo /sbin/vgs --noheadings --nosuf
 # Note, that the awk field parameters ($1 - $N) require double dollar sign
 # escaping ($$1) to prevent them from being interpreted as Zabbix positional
 # references.
-UserParameter=rabe.lvm.lvs.value[*],/usr/bin/sudo /sbin/lvs --noheadings --nosuffix --units b --options '$2' '$1' 2>/dev/null | /usr/bin/awk '{ print $$1 }'
+UserParameter=rabe.lvm.lvs.value[*],/usr/bin/sudo /sbin/lvs --noheadings --nolocking --nosuffix --units b --options '$2' '$1' 2>/dev/null | /usr/bin/awk '{ print $$1 }'


### PR DESCRIPTION
Adding `--nolocking` to the LVM commands to prevent SELinux denies on newer CentOS systems

```
type=AVC msg=audit(1704540662.912:347107): avc:  denied  { write } for  pid=504392 comm="pvs" name="D_system.devices" dev="tmpfs" ino=19738 scontext=system_u:system_r:zabbix_agent_t:s0 tcontext=system_u:object_r:lvm_lock_t:s0 tclass=file permissive=0
```