### PR TITLE
feat(EL7 Stack): Add chrony monitoring

### DIFF
--- a/Stacks/Operating_systems/EL7_Stack/6.4/EL7_Stack.yaml
+++ b/Stacks/Operating_systems/EL7_Stack/6.4/EL7_Stack.yaml
@@ -19,6 +19,7 @@ zabbix_export:
         - name: auditd
         - name: candlepin-rhsmcertd
         - name: certmonger
+        - name: chrony
         - name: Cronie
         - name: firewalld
         - name: gssproxy

--- a/Stacks/Operating_systems/EL7_Stack/6.4/README.md
+++ b/Stacks/Operating_systems/EL7_Stack/6.4/README.md
@@ -14,6 +14,7 @@ This Zabbix template depends on the following templates.
 * auditd
 * candlepin-rhsmcertd
 * certmonger
+* chrony
 * Cronie
 * firewalld
 * gssproxy


### PR DESCRIPTION
Some initial tests show that chrony works just as well on EL7 as it does on EL8+. Hence i'd like to switch to chrony for all client systems. I don't plan to touch nodes involved with providing NTP services. IMO this simplifies our setup because we can use the same monitoring and configuration principals for both environments. It will aid in shortening our internal NTP docs.

This is draft for now because i want to keep an eye on the EL7+ chrony test system i have so far and gradually add some more systems before fully committing.