### PR TITLE
chore(Songticker): add current track

### DIFF
--- a/Templates/Applications/Songticker/6.4/README.md
+++ b/Templates/Applications/Songticker/6.4/README.md
@@ -84,6 +84,58 @@ Preprocessing steps:
 | XMLPATH | `["/*[name()='ticker']/*[name()='show']/*[name()='name']/text()"]` |
 | DISCARD_UNCHANGED_HEARTBEAT | `["30m"]` |
 
+### Item: Songticker: Current Artist
+
+![component: songticker](https://img.shields.io/badge/component-songticker-00c9bf)
+
+Currently running artist.
+
+```console
+rabe.songticker.track_artist
+```
+
+Settings:
+
+| Item Setting | Value |
+| ------------ | ----- |
+| Type | DEPENDENT |
+| Value type | TEXT |
+| History | 7d |
+| Source item | `rabe.songticker.xml` |
+
+Preprocessing steps:
+
+| Type | Parameters |
+| ---- | ---------- |
+| XMLPATH | `["/*[name()='ticker']/*[name()='track']/*[name()='artist']/text()"]` |
+| DISCARD_UNCHANGED_HEARTBEAT | `["30m"]` |
+
+### Item: Songticker: Current Title
+
+![component: songticker](https://img.shields.io/badge/component-songticker-00c9bf)
+
+Currently running track.
+
+```console
+rabe.songticker.track_title
+```
+
+Settings:
+
+| Item Setting | Value |
+| ------------ | ----- |
+| Type | DEPENDENT |
+| Value type | TEXT |
+| History | 7d |
+| Source item | `rabe.songticker.xml` |
+
+Preprocessing steps:
+
+| Type | Parameters |
+| ---- | ---------- |
+| XMLPATH | `["/*[name()='ticker']/*[name()='track']/*[name()='title']/text()"]` |
+| DISCARD_UNCHANGED_HEARTBEAT | `["30m"]` |
+
 ### Item: Songticker XML reponse
 
 ![component: raw](https://img.shields.io/badge/component-raw-00c9bf)

--- a/Templates/Applications/Songticker/6.4/Songticker.yaml
+++ b/Templates/Applications/Songticker/6.4/Songticker.yaml
@@ -91,6 +91,48 @@ zabbix_export:
           tags:
             - tag: component
               value: songticker
+        - uuid: a503e836d6f6428d83d0a1cf35b98551
+          name: 'Songticker: Current Artist'
+          type: DEPENDENT
+          key: rabe.songticker.track_artist
+          delay: '0'
+          history: 7d
+          trends: '0'
+          value_type: TEXT
+          description: 'Currently running artist.'
+          preprocessing:
+            - type: XMLPATH
+              parameters:
+                - '/*[name()=''ticker'']/*[name()=''track'']/*[name()=''artist'']/text()'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 30m
+          master_item:
+            key: rabe.songticker.xml
+          tags:
+            - tag: component
+              value: songticker
+        - uuid: 4b158ace141648a7a1d2b5308ab6f4ec
+          name: 'Songticker: Current Title'
+          type: DEPENDENT
+          key: rabe.songticker.track_title
+          delay: '0'
+          history: 7d
+          trends: '0'
+          value_type: TEXT
+          description: 'Currently running track.'
+          preprocessing:
+            - type: XMLPATH
+              parameters:
+                - '/*[name()=''ticker'']/*[name()=''track'']/*[name()=''title'']/text()'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 30m
+          master_item:
+            key: rabe.songticker.xml
+          tags:
+            - tag: component
+              value: songticker
         - uuid: 17572c4eaaf64ccdae11785ada8f85b0
           name: 'Songticker XML reponse'
           type: HTTP_AGENT


### PR DESCRIPTION
This should help debug if PAD data goes missing somewhere because we can have a nicer overview directly in Zabbix.